### PR TITLE
#232 New options to control formatted log outputs

### DIFF
--- a/src/PBI-Tools/Deployments/DatasetGatewayManager.cs
+++ b/src/PBI-Tools/Deployments/DatasetGatewayManager.cs
@@ -19,11 +19,13 @@ namespace PbiTools.Deployments
         private static readonly ILogger Log = Serilog.Log.ForContext<DatasetGatewayManager>();
 
         private readonly Options _options;
+		private readonly PbiDeploymentOptions.ConsoleOptions _consoleOptions;
         private readonly IPowerBIClient _powerBI;
 
-        public DatasetGatewayManager(Options options, IPowerBIClient powerBIClient)
+        public DatasetGatewayManager(Options options, PbiDeploymentOptions.ConsoleOptions consoleOptions, IPowerBIClient powerBIClient)
         {
             _options = options;
+            _consoleOptions = consoleOptions ?? throw new ArgumentNullException(nameof(consoleOptions));
             _powerBI = powerBIClient ?? throw new ArgumentNullException(nameof(powerBIClient));
 
             Enabled = options != null && (options.GatewayId != default || options.DiscoverGateways);
@@ -42,7 +44,7 @@ namespace PbiTools.Deployments
 
             var gateways = await _powerBI.Datasets.DiscoverGatewaysInGroupAsync(workspaceId, datasetId);
 
-            var table = new Spectre.Console.Table { Width = Environment.UserInteractive ? null : 80 };
+            var table = new Spectre.Console.Table { Expand = _consoleOptions.ExpandTable };
 
             table.AddColumns("ID", "Name", "Type");
 

--- a/src/PBI-Tools/Deployments/DeploymentManager.Dataset.cs
+++ b/src/PBI-Tools/Deployments/DeploymentManager.Dataset.cs
@@ -301,7 +301,7 @@ namespace PbiTools.Deployments
                     }
                 }
 
-                ReportPartitionStatus(remoteDb.Model);
+                ReportPartitionStatus(remoteDb.Model, manifest.Options.Console);
             }
 
             if (!WhatIf || !createdNewDb)
@@ -323,7 +323,7 @@ namespace PbiTools.Deployments
             if (!WhatIf || !createdNewDb) {
                 var dataSources = await powerbi.Datasets.GetDatasourcesInGroupAsync(workspaceId, datasetId);
 
-                var table = new Spectre.Console.Table { Width = Environment.UserInteractive ? null : 80 };
+                var table = new Spectre.Console.Table { Expand = manifest.Options.Console.ExpandTable };
 
                 table.AddColumns(
                     nameof(Microsoft.PowerBI.Api.Models.Datasource.DatasourceType),
@@ -352,7 +352,7 @@ namespace PbiTools.Deployments
 
             #region Bind to Gateway (New dataset only)
 
-            var gatewayManager = new DatasetGatewayManager(dataset.Options.Dataset.Gateway, powerbi) { WhatIf = WhatIf };
+            var gatewayManager = new DatasetGatewayManager(dataset.Options.Dataset.Gateway, dataset.Options.Console, powerbi) { WhatIf = WhatIf };
 
             await gatewayManager.DiscoverGatewaysAsync(workspaceId, datasetId);
 
@@ -444,11 +444,12 @@ namespace PbiTools.Deployments
                                 {
                                     BasePath = basePath,
                                     ManifestOptions = dataset.Options.Refresh,
-                                    EnvironmentOptions = deploymentEnv.Refresh
+                                    EnvironmentOptions = deploymentEnv.Refresh,
+                                    ConsoleOptions = dataset.Options.Console
                                 }
                                 .RunRefresh();
 
-                                ReportPartitionStatus(db.Model);
+                                ReportPartitionStatus(db.Model, manifest.Options.Console);
                             }
                             break;
                         default:
@@ -463,7 +464,7 @@ namespace PbiTools.Deployments
 
         }
 
-        private static void ReportPartitionStatus(TOM.Model model)
+        private static void ReportPartitionStatus(TOM.Model model, PbiDeploymentOptions.ConsoleOptions consoleOptions)
         {
             var partitions = model.Tables
                 .SelectMany(t => t.Partitions)
@@ -480,7 +481,7 @@ namespace PbiTools.Deployments
                 })
                 .ToArray();
 
-            var table = new Spectre.Console.Table { Width = Environment.UserInteractive ? null : 80 };
+            var table = new Spectre.Console.Table { Expand = consoleOptions.ExpandTable };
 
             table.AddColumns(
                 nameof(TOM.Table),

--- a/src/PBI-Tools/Deployments/DeploymentManager.cs
+++ b/src/PBI-Tools/Deployments/DeploymentManager.cs
@@ -10,6 +10,7 @@ using Microsoft.PowerBI.Api;
 using Microsoft.Rest;
 using Serilog;
 using Serilog.Events;
+using Spectre.Console;
 
 namespace PbiTools.Deployments
 {
@@ -75,6 +76,12 @@ namespace PbiTools.Deployments
                     throw new DeploymentException($"The current project does not contain the specified deploymment '{profileName}'");
 
                 var manifest = _manifests[profileName];
+                
+                var prevConsoleWidth = AnsiConsole.Console.Profile.Width;
+                if (manifest.Options.Console.Width.HasValue) {
+                    AnsiConsole.Console.Profile.Width = manifest.Options.Console.Width.Value;
+                }
+                
                 switch (manifest.Mode)
                 {
                     case PbiDeploymentMode.Report:
@@ -85,6 +92,10 @@ namespace PbiTools.Deployments
                         break;
                     default:
                         throw new DeploymentException($"Unsupported deployment mode: '{manifest.Mode}'");
+                }
+
+                if (manifest.Options.Console.Width.HasValue) {
+                    AnsiConsole.Console.Profile.Width = prevConsoleWidth;
                 }
             }
 

--- a/src/PBI-Tools/Deployments/DeploymentManifest.cs
+++ b/src/PBI-Tools/Deployments/DeploymentManifest.cs
@@ -273,6 +273,9 @@ namespace PbiTools.Deployments
         [JsonProperty("sqlScripts")]
         public SqlScriptsOptions SqlScripts { get; set; } = new();
 
+        [JsonProperty("console")]
+        public ConsoleOptions Console { get; set; } = new();
+
 
         public class ImportOptions
         {
@@ -569,6 +572,21 @@ namespace PbiTools.Deployments
             }
         }
 
+        public class ConsoleOptions
+        { 
+            /// <summary>
+            /// If specified, sets an explicit console width. This setting can be useful with certain CI/CD runners.
+            /// </summary>
+            [JsonProperty("width")]
+            public int? Width { get; set; }
+
+            /// <summary>
+            /// Indicates whether or not tables printed to the console should fit the available space.
+            /// If <c>false</c>, the table width will be auto calculated. Defaults to <c>false</c>.
+            /// </summary>
+            [JsonProperty("expandTable"), DefaultValue(false)]
+            public bool ExpandTable { get; set; }
+        }
     }
 
     public class PbiDeploymentEnvironment

--- a/src/PBI-Tools/Deployments/XmlaRefreshManager.cs
+++ b/src/PBI-Tools/Deployments/XmlaRefreshManager.cs
@@ -28,6 +28,8 @@ namespace PbiTools.Deployments
 
         public PbiDeploymentEnvironment.RefreshOptions EnvironmentOptions { get; set; }
 
+        public PbiDeploymentOptions.ConsoleOptions ConsoleOptions { get; set; }
+
         private void RequestModelRefresh(TOM.RefreshType refreshType)
         {
             if (ManifestOptions.IgnoreRefreshPolicy)
@@ -88,7 +90,7 @@ namespace PbiTools.Deployments
                 }
             }
 
-            using var trace = new XmlaRefreshTrace(_database.Server, ManifestOptions.Tracing ?? new(), BasePath);
+            using var trace = new XmlaRefreshTrace(_database.Server, ManifestOptions.Tracing ?? new(), ConsoleOptions ?? new(), BasePath);
             trace.Start();
 
             try

--- a/src/PBI-Tools/Deployments/XmlaRefreshTrace.cs
+++ b/src/PBI-Tools/Deployments/XmlaRefreshTrace.cs
@@ -29,6 +29,7 @@ namespace PbiTools.Deployments
         private static readonly ILogger Log = Serilog.Log.ForContext<XmlaRefreshTrace>();
 
 		private readonly PbiDeploymentOptions.RefreshOptions.TraceOptions _options;
+		private readonly PbiDeploymentOptions.ConsoleOptions _consoleOptions;
 		private readonly string _basePath;
 		private readonly string _sessionId;
 		private readonly bool _processSummary;
@@ -37,9 +38,10 @@ namespace PbiTools.Deployments
 
 		private TOM.Trace trace;
 
-        public XmlaRefreshTrace(TOM.Server server, PbiDeploymentOptions.RefreshOptions.TraceOptions options, string basePath)
+        public XmlaRefreshTrace(TOM.Server server, PbiDeploymentOptions.RefreshOptions.TraceOptions options, PbiDeploymentOptions.ConsoleOptions consoleOptions, string basePath)
         {
 			_options = options ?? throw new ArgumentNullException(nameof(options));
+			_consoleOptions = consoleOptions ?? throw new ArgumentNullException(nameof(consoleOptions));
 			_basePath = basePath ?? throw new ArgumentNullException(nameof(basePath));
 
 			if (options.Enabled) {
@@ -223,7 +225,7 @@ namespace PbiTools.Deployments
 					{
 						if (_options.Summary.Console)
 						{
-							var table = new Table { Width = Environment.UserInteractive ? null : 80 };
+							var table = new Table { Expand = _consoleOptions.ExpandTable };
 
 							var properties = typeof(RefreshSummaryRecord).GetProperties();
 							Array.ForEach(properties, p => table.AddColumn(p.Name));


### PR DESCRIPTION
- New manifest setting manifest.options.console.width allows setting an explicit console width
- In conjunction with manifest.options.console.expandTable (default: false), this allows generating wider output tables if the default console width is limited (ex: it's only 80 on GitLab CI)
- Recommended to set width to larger size, for instance 200, in those scenarios